### PR TITLE
Add support for backspace characters

### DIFF
--- a/lib/ansiparse.js
+++ b/lib/ansiparse.js
@@ -7,7 +7,8 @@ ansiparse = function (str) {
       matchingText = '',
       ansiState = [],
       result = [],
-      state = {};
+      state = {},
+      eraseText;
 
   //
   // General workflow for this thing is:
@@ -19,6 +20,29 @@ ansiparse = function (str) {
   //
   // In further steps we hope it's all going to be fine. It usually is.
   //
+
+  //
+  // Erases a char from the output
+  //
+  eraseChar = function () {
+    var index, text;
+    if (matchingText.length) {
+      matchingText = matchingText.substr(0, matchingText.length - 1);
+    }
+    else if (result.length) {
+      index = result.length - 1;
+      text = result[index].text;
+      if (text.length === 1) {
+        //
+        // A result bit was fully deleted, pop it out to simplify the final output
+        //
+        result.pop();
+      }
+      else {
+        result[index].text = text.substr(0, text.length - 1);
+      }
+    }
+  };
 
   for (var i = 0; i < str.length; i++) {
     if (matchingControl != null) {
@@ -111,7 +135,9 @@ ansiparse = function (str) {
 
     if (str[i] == '\033') {
       matchingControl = str[i];
-
+    }
+    else if (str[i] == '\u0008') {
+      eraseChar();
     }
     else {
       matchingText += str[i];

--- a/test/ansiparse-test.js
+++ b/test/ansiparse-test.js
@@ -62,6 +62,14 @@ var dataSets = {
   'malformed control sequence': {
     input: '\033A string between two ESC\033',
     output: [ { text: '\033A string between two ESC\033' } ]
+  },
+  'simple backspace': {
+    input: 'hello '.green + 'worz\bld'.red,
+    output: [{ text: 'hello ', foreground: 'green' }, { text: 'world', foreground: 'red' }]
+  },
+  'backspace across blocks': {
+    input: 'hello'.green + ' ' + 'worz\b\b\b\b\bl    \b\b\b\b'.red,
+    output: [{ text: 'hello', foreground: 'green' }, { text: 'l', foreground: 'red' }]
   }
 };
 


### PR DESCRIPTION
Background: travis-ci uses this lib to display the console log - and when some script uses backspace chars (0x08) to move the cursor back and overwrite text, it kinda looks bad as you can see on http://travis-ci.org/#!/symfony/symfony/jobs/1118763 for example. All those black dots on white background should not show up.
