### PR TITLE
Don't check for window undefined

### DIFF
--- a/lib/ansiparse.js
+++ b/lib/ansiparse.js
@@ -180,7 +180,7 @@ ansiparse.styles = {
   '4': 'underline'
 };
 
-if (typeof module == "object" && typeof window == "undefined") {
+if (typeof module == "object") {
   module.exports = ansiparse;
 }
 


### PR DESCRIPTION
Checking for window undefined means this module can't be used with browserify
