### PR TITLE
Remove conditional around export

### DIFF
--- a/lib/ansiparse.js
+++ b/lib/ansiparse.js
@@ -180,7 +180,5 @@ ansiparse.styles = {
   '4': 'underline'
 };
 
-if (typeof module == "object" && typeof window == "undefined") {
-  module.exports = ansiparse;
-}
+module.exports = ansiparse;
 


### PR DESCRIPTION
Hey, I’m [changing `travis-web` to import `ansiparse` in a more NPM-y fashion](https://github.com/travis-ci/travis-web/pull/752). I forked your repository to remove this conditional because `window` is present when importing in-browser.

Let me know if this change works for you, or maybe you’d prefer to no longer have responsibility for this repository? Thanks for your work on it!