### PR TITLE
Consider using K in matchingData

### DIFF
--- a/lib/ansiparse.js
+++ b/lib/ansiparse.js
@@ -85,7 +85,7 @@ function ansiparse(str) {
         ansiState.push(matchingData);
         matchingData = '';
       }
-      else if (str[i] == 'm') {
+      else if (str[i] == 'm' || str[i] == 'K') {
         //
         // `m` finished whole formatting code. We can proceed to matching
         // formatted text.


### PR DESCRIPTION
When parsing result from `ag` https://github.com/ggreer/the_silver_searcher, I found it use sequence `\033\[K` as matchingData for end match.